### PR TITLE
Switch to using CGFloats so that we can add IBInspectable

### DIFF
--- a/TGColoredDisclosureAccessory.h
+++ b/TGColoredDisclosureAccessory.h
@@ -5,17 +5,18 @@
 // Modified by Tommy Goode on 7/16/12.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface TGColoredDisclosureAccessory : UIControl
 
-@property (nonatomic, strong) UIColor *accessoryColor;
-@property (nonatomic, strong) UIColor *highlightedColor;
+@property (nonatomic, strong) IBInspectable UIColor *accessoryColor;
+@property (nonatomic, strong) IBInspectable UIColor *highlightedColor;
 
-@property (nonatomic, strong) NSNumber *lineWidth;
-@property (nonatomic, strong) NSNumber *radius;
-@property (nonatomic, strong) NSNumber *rightPadding;
+@property (nonatomic, assign) IBInspectable CGFloat lineWidth;
+@property (nonatomic, assign) IBInspectable CGFloat radius;
+@property (nonatomic, assign) IBInspectable CGFloat rightPadding;
 
 + (TGColoredDisclosureAccessory *)accessoryWithColor:(UIColor *)color;
-+ (TGColoredDisclosureAccessory *)accessoryWithColor:(UIColor *)color radius:(NSNumber *)radius rightPadding:(NSNumber *)rightPadding;
++ (TGColoredDisclosureAccessory *)accessoryWithColor:(UIColor *)color radius:(CGFloat)radius rightPadding:(CGFloat)rightPadding;
+
 @end

--- a/TGColoredDisclosureAccessory.m
+++ b/TGColoredDisclosureAccessory.m
@@ -11,12 +11,12 @@
 
 #pragma mark - Class creation
 + (TGColoredDisclosureAccessory *)accessoryWithColor:(UIColor *)color {
-	return [TGColoredDisclosureAccessory accessoryWithColor:color radius:@4.5 rightPadding:@0];
+	return [TGColoredDisclosureAccessory accessoryWithColor:color radius:4.5 rightPadding:0];
 }
 
-+ (TGColoredDisclosureAccessory *)accessoryWithColor:(UIColor *)color radius:(NSNumber *)radius rightPadding:(NSNumber *)rightPadding {
-	CGFloat height = radius.floatValue * 2. + 6.;
-	CGFloat width = radius.floatValue + 6. + rightPadding.floatValue;
++ (TGColoredDisclosureAccessory *)accessoryWithColor:(UIColor *)color radius:(CGFloat)radius rightPadding:(CGFloat)rightPadding {
+	CGFloat height = radius * 2. + 6.;
+	CGFloat width = radius + 6. + rightPadding;
 	TGColoredDisclosureAccessory *accessory = [[TGColoredDisclosureAccessory alloc] initWithFrame:CGRectMake(0, 0, width, height)];
 	accessory.accessoryColor = color;
 	accessory.radius = radius;
@@ -25,27 +25,41 @@
 }
 
 #pragma mark - Lifecycle
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    self = [super initWithCoder:coder];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
 - (id)initWithFrame:(CGRect)frame {
 	if (self = [super initWithFrame:frame]) {
-		self.userInteractionEnabled = NO;
-		self.backgroundColor = [UIColor clearColor];
-		self.lineWidth = @3;
+        [self commonInit];
 	}
 	return self;
 }
 
+- (void)commonInit {
+    self.userInteractionEnabled = NO;
+    self.backgroundColor = [UIColor clearColor];
+    self.lineWidth = 3;
+    self.radius = 4.5;
+}
+
 - (void)drawRect:(CGRect)rect {
 	// (x,y) is the center of the head of the arrow
-	CGFloat x = CGRectGetMaxX(self.bounds) - 2.5 - self.rightPadding.floatValue;
+	CGFloat x = CGRectGetMaxX(self.bounds) - 2.5 - self.rightPadding;
 	CGFloat y = CGRectGetMidY(self.bounds);
-	const CGFloat R = self.radius.floatValue;
+	const CGFloat R = self.radius;
 	CGContextRef ctxt = UIGraphicsGetCurrentContext();
 	CGContextMoveToPoint(ctxt, x - R, y - R);
 	CGContextAddLineToPoint(ctxt, x, y);
 	CGContextAddLineToPoint(ctxt, x - R, y + R);
 	CGContextSetLineCap(ctxt, kCGLineCapSquare);
 	CGContextSetLineJoin(ctxt, kCGLineJoinMiter);
-	CGContextSetLineWidth(ctxt, self.lineWidth.floatValue);
+	CGContextSetLineWidth(ctxt, self.lineWidth);
 
 	if (self.highlighted) {
 		[self.highlightedColor setStroke];

--- a/TGColoredDisclosureAccessory.podspec
+++ b/TGColoredDisclosureAccessory.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "TGColoredDisclosureAccessory"
-  s.version          = "0.1.0"
+  s.version          = "1.0.0"
   s.summary          = "A configurable reimplementation of UITableViewCell's disclosure indicator."
   s.homepage         = "https://github.com/airdrummingfool/TGColoredDisclosureAccessory"
   s.license          = 'MIT'

--- a/TGColoredDisclosureAccessory.podspec
+++ b/TGColoredDisclosureAccessory.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name             = "TGColoredDisclosureAccessory"
+  s.version          = "0.1.0"
+  s.summary          = "A configurable reimplementation of UITableViewCell's disclosure indicator."
+  s.homepage         = "https://github.com/airdrummingfool/TGColoredDisclosureAccessory"
+  s.license          = 'MIT'
+  s.author           = { "Tommy Goode" => "" }
+  s.source           = { :git => "https://github.com/airdrummingfool/TGColoredDisclosureAccessory.git", :tag => s.version.to_s }
+
+  s.platform     = :ios, '7.0'
+  s.requires_arc = true
+  s.source_files = 'TGColoredDisclosureAccessory.{h,m}'
+  s.frameworks = 'UIKit'
+end


### PR DESCRIPTION
This allows us to configure the view in Interface Builder. I also added a podspec to make use with CocoaPods easier, and set the version number to 1.0.0 as this is a breaking change. Should be an easy upgrade path though as the compiler will pick up any build errors.
